### PR TITLE
fix: run build problem from api vocabularies

### DIFF
--- a/web/app/api/v1/users/vocabularies/[id]/route.ts
+++ b/web/app/api/v1/users/vocabularies/[id]/route.ts
@@ -22,14 +22,33 @@ router.get(getVocabulariesFlashcard);
 router.post(postVocabulariesFlashcard);
 router.delete(deleteVocabulariesFlashcard);
 
-export async function GET(request: NextRequest, ctx: RequestContext) {
-  return router.run(request, ctx);
+export async function GET(
+  request: NextRequest,
+  ctx: RequestContext
+): Promise<Response> {
+  return handleRouterResponse(await router.run(request, ctx));
 }
 
-export async function POST(request: NextRequest, ctx: RequestContext) {
-  return router.run(request, ctx);
+export async function POST(
+  request: NextRequest,
+  ctx: RequestContext
+): Promise<Response> {
+  return handleRouterResponse(await router.run(request, ctx));
 }
 
-export async function DELETE(request: NextRequest, ctx: RequestContext) {
-  return router.run(request, ctx);
+export async function DELETE(
+  request: NextRequest,
+  ctx: RequestContext
+): Promise<Response> {
+  return handleRouterResponse(await router.run(request, ctx));
+}
+
+function handleRouterResponse(response: unknown): Response {
+  if (response instanceof Response) {
+    return response;
+  }
+  return new Response(JSON.stringify(response), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 }


### PR DESCRIPTION
The issue is that router.run(request, ctx) might return a non-Response value, so we need to ensure it always returns a valid Response.