### PR TITLE
Kit/fix/type safety in dashboard

### DIFF
--- a/web/components/dashboard/class-detail-dashboard.tsx
+++ b/web/components/dashboard/class-detail-dashboard.tsx
@@ -34,6 +34,7 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { useScopedI18n } from "@/locales/client";
+import { ScopedI18n } from "@/locales/locales";
 
 export interface ClassDetailDashboardProps {
   classroomId: string;
@@ -47,7 +48,8 @@ export function ClassDetailDashboard({
   classCode,
 }: ClassDetailDashboardProps) {
   const router = useRouter();
-  const t = useScopedI18n("pages.teacher.dashboardPage.classDetail") as any;
+  const scope = "pages.teacher.dashboardPage.classDetail" as const;
+  const t = useScopedI18n(scope) as ScopedI18n<typeof scope>;
   const [refreshing, setRefreshing] = useState(false);
   const [activeTab, setActiveTab] = useState("overview");
 
@@ -197,8 +199,8 @@ export function ClassDetailDashboard({
         </TabsContent>
 
         <TabsContent value="goals" className="space-y-4">
-          <ClassroomGoalsManagement 
-            classroomId={classroomId} 
+          <ClassroomGoalsManagement
+            classroomId={classroomId}
             className={className}
           />
         </TabsContent>

--- a/web/locales/locales.ts
+++ b/web/locales/locales.ts
@@ -1,0 +1,27 @@
+import en from "./en";
+
+export type LocaleDictionary = typeof en;
+
+type PathValue<T, P extends string> = P extends `${infer K}.${infer Rest}`
+	? K extends keyof T
+		? PathValue<T[K & keyof T], Rest>
+		: never
+	: P extends keyof T
+	? T[P]
+	: never;
+
+type NestedKeys<T> = T extends string
+	? never
+	: {
+			[K in keyof T & string]: K | `${K}.${NestedKeys<T[K]>}`;
+		}[keyof T & string];
+
+export type ScopedKey<S extends string> = NestedKeys<
+	PathValue<LocaleDictionary, S>
+>;
+
+export type ScopedI18n<S extends string> = (key: ScopedKey<S>) => string;
+
+export type RootLocale = LocaleDictionary;
+
+


### PR DESCRIPTION
Create a TypeScript type to enable the retrieval of specific scoped text.

Fix: web\components\dashboard\class-detail-dashboard.tsx
Feat: web\locales\locales.ts